### PR TITLE
Update to react peerDependency to 0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "react": "^0.12.2"
+    "react": "0.13.x"
   }
 }


### PR DESCRIPTION
It use ```0.13.x``` instead of ```>= 0.13.0``` as many other repositories do the same thing. Also, 0.14 will include some changes, so at the moment, it's better to remain at 0.13.