### PR TITLE
Configuration for Brand.ai component documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 A React wrapper around WinJS's controls. Implemented using the technique described on [this WinJS wiki page](https://github.com/winjs/winjs/wiki/Using-WinJS-with-React).
 
-[Documentation](https://github.com/winjs/react-winjs/wiki/Documentation)
+  - [Documentation](https://github.com/winjs/react-winjs/wiki/Documentation)
+  - [Live Component Library](https://brand.ai/styleguide/WinJS)
 
 Live demos:
   - [Showcase](http://winjs.github.io/react-winjs/examples/showcase/index.html) ([source](https://github.com/winjs/react-winjs/tree/master/examples/showcase)): shows an example usage of each component.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,47 @@
+# React-WinJS Component Documentation (see it live [here](https://brandai.com/styleguide/WinJS))
+
+This folder contains configuration required to build documentation for react-winjs using [Brand AI](https://brand.ai).
+
+## Flow
+### Build
+Use gulp to build a distribution folder containing:
+* library version of react-winjs
+* WinJS core scripts and stylesheets.
+
+See [webpack.config.json](https://github.com/winjs/react-winjs/blob/master/docs/webpack.config.js) and [gulpfile.json](https://github.com/winjs/react-winjs/blob/master/docs/gulpfile.js) for more info on that.
+
+```sh
+$ npm install
+$ gulp build
+```
+
+### Deploy
+Deploying to Brand.ai is done through [brandai-tools](https://github.com/brandai/brandai-tools).
+```sh
+$ npm install -g brandai-tools
+$ brandai login
+$ brandai deploy
+```
+
+### Config
+[brandai.json](https://github.com/brandai/react-winjs/blob/master/docs/brandai.json) contains all the component extraction and deployment information.
+
+* `name` - the component library name in Brand.ai - each documentation project is associated with one or more component libraries
+* `libraryPath` - relative path for the component library project root (used to read library package.json)
+* `dist` - name of the dist folder containing the library and its dependencies - used both for rendering examples and for dynamic analysis of components and their properties
+* `libraryObjectName` - name of the library on the global object (we set it to `ReactWinJS` in `webpack.config.js`.
+* `reactVersion` - the version of React required for running this library (automatically gets pulled when rendering the components)
+* `dynamicExtraction` - this tells Brand.ai to dynamically extract components - run the files in the `dist` folder and extract the required info from live components, rather than statically parse .jsx files.
+* `fileOrder` - when loading dependencies, file names appearing here will be loaded first (we can't load react-winjs until the winjs core files are there).
+
+#### Example package.json
+```json
+{
+  "name": "react-winjs",
+  "libraryPath": "../",
+  "dist": "dist",
+  "libraryObjectName": "ReactWinJS",
+  "reactVersion": "0.13.3",
+  "dynamicExtraction": true,
+  "fileOrder": ["base.min.js", "ui.min.js"]
+}

--- a/docs/brandai.json
+++ b/docs/brandai.json
@@ -1,0 +1,9 @@
+{
+  "name": "react-winjs-brandai",
+  "libraryPath": "../",
+  "dist": "dist",
+  "libraryObjectName": "ReactWinJS",
+  "reactVersion": "0.13.3",
+  "dynamicExtraction": true,
+  "fileOrder": ["base.min.js", "ui.min.js"]
+}

--- a/docs/gulpfile.js
+++ b/docs/gulpfile.js
@@ -1,0 +1,28 @@
+var gulp = require("gulp");
+var gutil = require("gulp-util");
+var webpack = require("webpack");
+
+gulp.task("build", ["build:webpack", "build:winjs"]);
+
+/*
+ Copy over core winjs files to the dist folder
+ */
+gulp.task("build:winjs", function() {
+  return gulp.src([
+    'node_modules/winjs/js/base.min.js',
+    'node_modules/winjs/js/ui.min.js',
+    'node_modules/winjs/css/ui-light.min.css',
+    'node_modules/winjs/fonts/*'
+  ], { base: 'node_modules/winjs' }).pipe(gulp.dest('dist'))
+});
+
+/*
+ Build library
+ */
+gulp.task("build:webpack", function(callback) {
+  webpack(require('./webpack.config'), function(err, stats) {
+    if(err) throw new gutil.PluginError("webpack", err);
+    gutil.log("[webpack]", stats.toString());
+    callback();
+  });
+});

--- a/docs/library.jsx
+++ b/docs/library.jsx
@@ -1,0 +1,1 @@
+module.exports = require('../react-winjs.js');

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "react-winjs-brandai-config",
+  "version": "0.0.0",
+  "description": "Configuration for brand.ai component documentation",
+  "author": "",
+  "license": "",
+  "dependencies": {},
+  "devDependencies": {
+    "gulp": "^3.9.0",
+    "gulp-util": "^3.0.6",
+    "jsx-loader": "^0.13.2",
+    "webpack": "^1.12.2",
+    "winjs": "^4.3.0"
+  }
+}

--- a/docs/webpack.config.js
+++ b/docs/webpack.config.js
@@ -1,0 +1,21 @@
+var path = require('path');
+/*
+ Export react-winjs as a library object (a ReactWinJS var).
+ */
+module.exports = {
+  entry: './library.jsx',
+  output: {
+    filename: 'dist/browser-bundle.js',
+    library: 'ReactWinJS',
+    libraryTarget: 'var'
+  },
+  module: {
+    loaders: [
+      {test: /\.jsx/, loader: 'jsx-loader'}
+    ]
+  },
+  externals: {
+    'react': 'React',
+    'react/addons': 'React'
+  }
+};


### PR DESCRIPTION
[See documentation here](https://brand.ai/styleguide/WinJS)

Pull request contains configuration for building and deploying [brand.ai](https://brand.ai) component documentation for react-winjs - located at a new folder under examples/brandai/ .

It could be used to document react-winjs itself, and also as a starting point to create live documentation for projects derived/evolved from react-winjs.