### PR TITLE
Initial work to update to React 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Then require `react-winjs` and use it:
 
 ```jsx
 var React = require('react');
+var ReactDOM = require('react-dom');
 var ReactWinJS = require('react-winjs');
 
 var App = React.createClass({
@@ -38,7 +39,7 @@ var App = React.createClass({
   }
 });
 
-React.render(<App />, document.getElementById("app"));
+ReactDOM.render(<App />, document.getElementById("app"));
 ```
 
 See the [documentation](https://github.com/winjs/react-winjs/wiki/Documentation) and [examples](https://github.com/winjs/react-winjs/tree/master/examples) for more details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ $ brandai deploy
   "libraryPath": "../",
   "dist": "dist",
   "libraryObjectName": "ReactWinJS",
-  "reactVersion": "0.13.3",
+  "reactVersion": "0.14.0",
   "dynamicExtraction": true,
   "fileOrder": ["base.min.js", "ui.min.js"]
 }

--- a/docs/brandai.json
+++ b/docs/brandai.json
@@ -3,7 +3,7 @@
   "libraryPath": "../",
   "dist": "dist",
   "libraryObjectName": "ReactWinJS",
-  "reactVersion": "0.13.3",
+  "reactVersion": "0.14.0",
   "dynamicExtraction": true,
   "fileOrder": ["base.min.js", "ui.min.js"]
 }

--- a/examples/address-book/index.html
+++ b/examples/address-book/index.html
@@ -6,7 +6,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="msapplication-tap-highlight" content="no">
 
-        <script src="http://fb.me/react-0.13.3.js"></script>
+        <script src="http://fb.me/react-0.14.0.js"></script>
+        <script src="http://fb.me/react-dom-0.14.0.js"></script>
 
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/winjs/4.4.0/css/ui-light.css" />
 

--- a/examples/address-book/index.jsx
+++ b/examples/address-book/index.jsx
@@ -1,6 +1,7 @@
 /** @jsx React.DOM */
 
 var React = require('react');
+var ReactDOM = require('react-dom');
 var ReactWinJS = require('react-winjs');
 var PeoplePage = require('./PeoplePage.jsx');
 var OtherPage = require('./OtherPage.jsx');
@@ -65,7 +66,7 @@ var App = React.createClass({
     handleResize: function () {
         var prevMode = this.state.mode;
         var nextMode = getMode();
-            
+
         if (prevMode !== nextMode) {
             this.setState({ mode: nextMode });
         }
@@ -196,4 +197,4 @@ var App = React.createClass({
     }
 });
 
-React.render(<App />, document.getElementById("app"));
+ReactDOM.render(<App />, document.getElementById("app"));

--- a/examples/address-book/package.json
+++ b/examples/address-book/package.json
@@ -9,10 +9,6 @@
   },
   "author": "",
   "license": "",
-  "peerDependencies": {
-    "react": "0.14.x",
-    "react-dom": "0.14.x"
-  },
   "devDependencies": {
     "jsx-loader": "^0.13.2",
     "webpack": "^1.9.4"

--- a/examples/address-book/package.json
+++ b/examples/address-book/package.json
@@ -10,7 +10,8 @@
   "author": "",
   "license": "",
   "dependencies": {
-    "react": "^0.13.3"
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
   },
   "devDependencies": {
     "jsx-loader": "^0.13.2",

--- a/examples/address-book/package.json
+++ b/examples/address-book/package.json
@@ -9,9 +9,9 @@
   },
   "author": "",
   "license": "",
-  "dependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+  "peerDependencies": {
+    "react": "0.14.x",
+    "react-dom": "0.14.x"
   },
   "devDependencies": {
     "jsx-loader": "^0.13.2",

--- a/examples/address-book/webpack.config.js
+++ b/examples/address-book/webpack.config.js
@@ -18,6 +18,6 @@ module.exports = {
   },
   externals: {
     'react': 'React',
-    'react/addons': 'React'
+    'react-dom': 'ReactDOM'
   }
 };

--- a/examples/movies/index.html
+++ b/examples/movies/index.html
@@ -6,7 +6,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="msapplication-tap-highlight" content="no">
 
-        <script src="http://fb.me/react-0.13.3.js"></script>
+        <script src="http://fb.me/react-0.14.0.js"></script>
+        <script src="http://fb.me/react-dom-0.14.0.js"></script>
 
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/winjs/4.4.0/css/ui-light.css" />
         <script src="https://cdnjs.cloudflare.com/ajax/libs/winjs/4.4.0/js/base.js"></script>

--- a/examples/movies/index.jsx
+++ b/examples/movies/index.jsx
@@ -1,6 +1,7 @@
 /** @jsx React.DOM */
 
 var React = require('react');
+var ReactDOM = require('react-dom');
 var ReactWinJS = require('react-winjs');
 var FakeData = require('./FakeData');
 var Data = FakeData;
@@ -163,4 +164,4 @@ var App = React.createClass({
     }
 });
 
-React.render(<App />, document.getElementById("app"));
+ReactDOM.render(<App />, document.getElementById("app"));

--- a/examples/movies/package.json
+++ b/examples/movies/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "",
   "dependencies": {
-    "react": "^0.13.3"
+    "react": "^0.14.0"
   },
   "devDependencies": {
     "jsx-loader": "^0.13.2",

--- a/examples/movies/package.json
+++ b/examples/movies/package.json
@@ -9,10 +9,6 @@
   },
   "author": "",
   "license": "",
-  "peerDependencies": {
-    "react": "0.14.x",
-    "react-dom": "0.14.x"
-  },
   "devDependencies": {
     "jsx-loader": "^0.13.2",
     "webpack": "^1.9.4"

--- a/examples/movies/package.json
+++ b/examples/movies/package.json
@@ -9,8 +9,9 @@
   },
   "author": "",
   "license": "",
-  "dependencies": {
-    "react": "^0.14.0"
+  "peerDependencies": {
+    "react": "0.14.x",
+    "react-dom": "0.14.x"
   },
   "devDependencies": {
     "jsx-loader": "^0.13.2",

--- a/examples/movies/webpack.config.js
+++ b/examples/movies/webpack.config.js
@@ -18,6 +18,6 @@ module.exports = {
   },
   externals: {
     'react': 'React',
-    'react/addons': 'React'
+    'react-dom': 'ReactDOM'
   }
 };

--- a/examples/showcase/index.html
+++ b/examples/showcase/index.html
@@ -6,7 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="msapplication-tap-highlight" content="no">
 
-    <script src="http://fb.me/react-0.13.3.js"></script>
+    <script src="http://fb.me/react-0.14.0.js"></script>
+    <script src="http://fb.me/react-dom-0.14.0.js"></script>
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/winjs/4.4.0/css/ui-light.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/winjs/4.4.0/js/base.js"></script>

--- a/examples/showcase/index.jsx
+++ b/examples/showcase/index.jsx
@@ -1,6 +1,7 @@
 /** @jsx React.DOM */
 
 var React = require('react');
+var ReactDOM = require('react-dom');
 var ReactWinJS = require('react-winjs');
 
 // title is:
@@ -95,4 +96,4 @@ var App = React.createClass({
     }
 });
 
-React.render(<App />, document.getElementById("app"));
+ReactDOM.render(<App />, document.getElementById("app"));

--- a/examples/showcase/package.json
+++ b/examples/showcase/package.json
@@ -9,10 +9,6 @@
   },
   "author": "",
   "license": "",
-  "peerDependencies": {
-    "react": "0.14.x",
-    "react-dom": "0.14.x"
-  },
   "devDependencies": {
     "jsx-loader": "^0.13.2",
     "webpack": "^1.9.4"

--- a/examples/showcase/package.json
+++ b/examples/showcase/package.json
@@ -10,7 +10,8 @@
   "author": "",
   "license": "",
   "dependencies": {
-    "react": "^0.13.3"
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
   },
   "devDependencies": {
     "jsx-loader": "^0.13.2",

--- a/examples/showcase/package.json
+++ b/examples/showcase/package.json
@@ -9,9 +9,9 @@
   },
   "author": "",
   "license": "",
-  "dependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+  "peerDependencies": {
+    "react": "0.14.x",
+    "react-dom": "0.14.x"
   },
   "devDependencies": {
     "jsx-loader": "^0.13.2",

--- a/examples/showcase/webpack.config.js
+++ b/examples/showcase/webpack.config.js
@@ -18,6 +18,6 @@ module.exports = {
   },
   externals: {
     'react': 'React',
-    'react/addons': 'React'
+    'react-dom': 'ReactDOM'
   }
 };

--- a/package.json
+++ b/package.json
@@ -16,11 +16,6 @@
     "url": "https://github.com/winjs/react-winjs"
   },
   "license": "MIT",
-  "peerDependencies": {
-    "react": "0.14.x",
-    "react-dom": "0.14.x",
-    "winjs": "4.4.x"
-  },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "react": "0.13.x",
+    "react": "0.14.x",
+    "react-dom": "0.14.x",
     "winjs": "4.4.x"
   },
   "devDependencies": {

--- a/react-winjs.js
+++ b/react-winjs.js
@@ -1,4 +1,6 @@
-﻿var React = require('react');
+var React = require('react');
+var ReactDOM = require('react-dom');
+
 
 //
 // Implementation Overview
@@ -39,9 +41,9 @@
 //
 // What made this challenging to solve is that there are some features that aren't achievable in
 // a straight forward way through the React APIs. To solve this, you want to be able to:
-//   - Render a React component *onto* an existing element. React.render can only render *into* an
+//   - Render a React component *onto* an existing element. ReactDOM.render can only render *into* an
 //     existing element. For example, when creating a HubSection you want to be able to control
-//     attributes of the win-hub-section element such as its *class* and *style*. With React.render,
+//     attributes of the win-hub-section element such as its *class* and *style*. With ReactDOM.render,
 //     you'd only be able to render into the win-hub-section element so the React component wouldn't
 //     be able to control any attributes of the win-hub-section element.
 //   - Hold onto a rendered component and inspect its *type* and *key* prop later. This information
@@ -1835,7 +1837,7 @@ function applyEditsToBindingList(list, edits) {
 function processChildren(componentDisplayName, children, childComponentsMap) {
     var newChildComponents = [];
     var newChildComponentsMap = {};
-    
+
     // A component's *key* represents its identity. If a component in *children* and a
     // component in *childComponentsMap* have the same *key*, then they are assumed to
     // represent the same component.
@@ -2112,7 +2114,7 @@ var PropHandlers = {
             preCtorInit: function propertyWithMount_preCtorInit(element, options, data, displayName, propName, value) {
                 if (value) {
                     data[propName] = document.createElement("div");
-                    React.render(value, data[propName]);
+                    ReactDOM.render(value, data[propName]);
                     options[winControlProperty] = data[propName];
                 }
             },
@@ -2124,18 +2126,18 @@ var PropHandlers = {
                         element = document.createElement("div");
                         winjsComponent.data[propName] = element;
                     }
-                    React.render(newValue, element);
+                    ReactDOM.render(newValue, element);
                     if (winControl[winControlProperty] !== element) {
                         winControl[winControlProperty] = element;
                     }
                 } else if (oldValue) {
-                    element && React.unmountComponentAtNode(element);
+                    element && ReactDOM.unmountComponentAtNode(element);
                     winControl[winControlProperty] = null;
                 }
             },
             dispose: function propertyWithMount_dispose(winjsComponent, propName) {
                 var element = winjsComponent.data[propName];
-                element && React.unmountComponentAtNode(element);
+                element && ReactDOM.unmountComponentAtNode(element);
             }
         };
     },
@@ -2166,13 +2168,13 @@ var PropHandlers = {
                         if (newValue) {
                             var newElement = getMountPoint(winjsComponent);
                             if (oldElement && oldElement !== newElement) {
-                                React.unmountComponentAtNode(oldElement);
+                                ReactDOM.unmountComponentAtNode(oldElement);
                             }
 
-                            React.render(newValue, newElement);
+                            ReactDOM.render(newValue, newElement);
                             winjsComponent.data[propName].element = newElement;
                         } else if (oldValue) {
-                            oldElement && React.unmountComponentAtNode(oldElement);
+                            oldElement && ReactDOM.unmountComponentAtNode(oldElement);
                             winjsComponent.data[propName].element = null;
                         }
                     }
@@ -2195,7 +2197,7 @@ var PropHandlers = {
             dispose: function mountTo_dispose(winjsComponent, propName) {
                 var data = winjsComponent.data[propName] || {};
                 var element = data.element;
-                element && React.unmountComponentAtNode(element);
+                element && ReactDOM.unmountComponentAtNode(element);
             }
         };
     },
@@ -2234,7 +2236,7 @@ var PropHandlers = {
                         return winjsChildComponent.winControl;
                     }));
                 }
-                
+
                 winjsComponent.data[propName] = {
                     winjsChildComponents: latest.childComponents,
                     winjsChildComponentsMap: latest.childComponentsMap
@@ -2279,7 +2281,7 @@ function defineControl(options) {
                 handler.preCtorInit(element, options, winjsComponent.data, displayName, propName, props[propName]);
             }
         });
-        winjsComponent.winControl = new winjsControl(element, options);        
+        winjsComponent.winControl = new winjsControl(element, options);
 
         // Process propHandlers that don't implement preCtorInit.
         Object.keys(props).forEach(function (propName) {
@@ -2335,7 +2337,7 @@ function defineControl(options) {
         // will run when WinJSChildComponent renders the component to a string via
         // renderRootlessComponent.
         componentDidMount: function () {
-            initWinJSComponent(this, React.findDOMNode(this), this.props);
+            initWinJSComponent(this, ReactDOM.findDOMNode(this), this.props);
         },
         componentWillUnmount: function () {
             disposeWinJSComponent(this);
@@ -2351,7 +2353,7 @@ function defineControl(options) {
 
 var hostEl = document.createElement("div");
 function renderRootlessComponent(component) {
-    var html = React.renderToStaticMarkup(component);
+    var html = ReactDOM.renderToStaticMarkup(component);
     hostEl.innerHTML = html;
     var element = hostEl.firstElementChild;
     hostEl.removeChild(element);
@@ -2362,7 +2364,7 @@ function renderRootlessComponent(component) {
 // TODO: Because we're not going thru React's lifecycle, we're missing out on
 // validation of propTypes.
 // TODO: ref doesn't work on WinJSChildComponents. The reason is that during updates, we
-// don't call React.render. Because of this, refs would go stale and only reflect the
+// don't call ReactDOM.render. Because of this, refs would go stale and only reflect the
 // state of the component after its first render. Consequently, we clone the component
 // during its first render so it never shows up in refs. This should make it clearer
 // that refs don't work than generating stale refs.
@@ -2508,7 +2510,7 @@ var CommandSpecs = {
                         };
                     }
                     var oldWinControl = data.flyoutComponent && data.flyoutComponent.winControl;
-                    var instance = React.render(newValue, data.flyoutHost);
+                    var instance = ReactDOM.render(newValue, data.flyoutHost);
                     if (oldWinControl !== instance.winControl) {
                         winjsComponent.winControl.flyout = instance.winControl;
                     }
@@ -2517,7 +2519,7 @@ var CommandSpecs = {
                 dispose: function FlyoutCommand_flyoutComponent_dispose(winjsComponent, propName) {
                     var data = winjsComponent.data[propName];
                     if (data && data.flyoutHost) {
-                        React.unmountComponentAtNode(data.flyoutHost);
+                        ReactDOM.unmountComponentAtNode(data.flyoutHost);
                         deparent(data.flyoutHost);
                     }
                 }
@@ -2620,7 +2622,7 @@ var ControlApis = updateWithDefaults({
                 // multiple components whereas the other technique restricts it to one.
                 update: function (winjsComponent, propName, oldValue, newValue) {
                     // TODO: dispose
-                    React.render(React.DOM.div(null, newValue), winjsComponent.winControl.element);
+                    ReactDOM.render(React.DOM.div(null, newValue), winjsComponent.winControl.element);
                 }
             }
         }
@@ -2823,9 +2825,9 @@ ReactWinJS.reactRenderer = function reactRenderer(componentFunction) {
     var renderItem = function renderItem(item) {
         var element = document.createElement("div");
         element.className = "win-react-renderer-host";
-        React.render(componentFunctionBound(item), element);
+        ReactDOM.render(componentFunctionBound(item), element);
         WinJS.Utilities.markDisposable(element, function () {
-            React.unmountComponentAtNode(element);
+            ReactDOM.unmountComponentAtNode(element);
         });
         return element;
     };

--- a/react-winjs.js
+++ b/react-winjs.js
@@ -1,6 +1,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
-var ReactDOMServer = require('react-dom/server')
+var ReactDOMServer = require('react-dom/server');
+var WinJS = require("winjs");
 
 //
 // Implementation Overview

--- a/react-winjs.js
+++ b/react-winjs.js
@@ -2079,15 +2079,17 @@ var PropHandlers = {
             if (oldValue !== newValue) {
                 oldValue = oldValue || {};
                 newValue = newValue || {};
-                var elementStyle = winjsComponent.winControl.element.style;
-                for (var cssProperty in oldValue) {
-                    if (!newValue.hasOwnProperty(cssProperty)) {
-                        elementStyle[cssProperty] = "";
+                if(winjsComponent.winControl && winjsComponent.winControl.element) {
+                    var elementStyle = winjsComponent.winControl.element.style;
+                    for (var cssProperty in oldValue) {
+                        if (!newValue.hasOwnProperty(cssProperty)) {
+                            elementStyle[cssProperty] = "";
+                        }
                     }
-                }
-                for (var cssProperty in newValue) {
-                    if (oldValue[cssProperty] !== newValue[cssProperty]) {
-                        elementStyle[cssProperty] = resolveStyleValue(cssProperty, newValue[cssProperty]);
+                    for (var cssProperty in newValue) {
+                        if (oldValue[cssProperty] !== newValue[cssProperty]) {
+                            elementStyle[cssProperty] = resolveStyleValue(cssProperty, newValue[cssProperty]);
+                        }
                     }
                 }
             }

--- a/react-winjs.js
+++ b/react-winjs.js
@@ -1,6 +1,6 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
-
+var ReactDOMServer = require('react-dom/server')
 
 //
 // Implementation Overview
@@ -2353,7 +2353,7 @@ function defineControl(options) {
 
 var hostEl = document.createElement("div");
 function renderRootlessComponent(component) {
-    var html = ReactDOM.renderToStaticMarkup(component);
+    var html = ReactDOMServer.renderToStaticMarkup(component);
     hostEl.innerHTML = html;
     var element = hostEl.firstElementChild;
     hostEl.removeChild(element);


### PR DESCRIPTION

Here's a kick-start to updating to React 0.14 as mentioned in #30.

Something is not yet working. I'm using the `examples/showcase` which is giving the following errors when loading up in the browser.

```
Warning: React can't find the root component node for data-reactid value `.0.0.3:$BackButton.1`. If you're seeing this message, it probably means that you've loaded two copies of React on the page. At this time, only a single copy of React can be loaded at a time.warning @ browser-bundle.js:23541ReactMount.findComponentRoot @ browser-bundle.js:24412ReactMount.findReactNodeByID @ browser-bundle.js:24379getNodeFromInstance @ browser-bundle.js:23885findDOMNode @ browser-bundle.js:31993React.createClass.componentDidMount @ browser-bundle.js:21054assign.notifyAll @ browser-bundle.js:6432ON_DOM_READY_QUEUEING.close @ browser-bundle.js:16171Mixin.closeAll @ browser-bundle.js:6793Mixin.perform @ browser-bundle.js:6740batchedMountComponentIntoNode @ browser-bundle.js:2669Mixin.perform @ browser-bundle.js:6727ReactDefaultBatchingStrategy.batchedUpdates @ browser-bundle.js:10749batchedUpdates @ browser-bundle.js:6232ReactMount._renderNewRootComponent @ browser-bundle.js:2863ReactPerf.measure.wrapper @ browser-bundle.js:1457ReactMount._renderSubtreeIntoContainer @ browser-bundle.js:2932ReactMount.render @ browser-bundle.js:2952ReactPerf.measure.wrapper @ browser-bundle.js:1457module.exports @ browser-bundle.js:147__webpack_require__ @ browser-bundle.js:20(anonymous function) @ browser-bundle.js:40(anonymous function) @ browser-bundle.js:43
browser-bundle.js:24415 Uncaught TypeError: Cannot read property 'firstChild' of undefined
```