### PR TITLE
Fix setImmediate call for IE and Edge

### DIFF
--- a/react-winjs.js
+++ b/react-winjs.js
@@ -1959,7 +1959,7 @@ var PropHandlers = {
                 if (oldValue !== newValue) {
                     var asyncToken = winjsComponent.data[propName];
                     asyncToken && clearImmediate(asyncToken);
-                    asyncToken = setImmediate(function () {
+                    asyncToken = setImmediate.call(undefined, function () {
                         winjsComponent.data[propName] = null;
                         winjsComponent.winControl[propName] = newValue;
                     });


### PR DESCRIPTION
Calling `setImmediate` was throwing an error when invoking it directly. 
It produced an "invalid calling object" error. Calling with a `.call` seems to fix the issue.